### PR TITLE
fix: npm publish access restricted

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "object-based-media-schema",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "JSON schemas which describe a common language for object-based media",
     "main": "lib/validate.js",
     "keywords": ["BBC", "BBC Research & Development", "schema", "interactive", "media", "object", "personalised"],

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
         "test": "./bin/validate_samples.sh",
         "schemaUI": "nodemon -L --watch schemas/ --exec node schemaUI/server.js"
     },
+    "publishConfig": {
+        "access": "public"
+    },    
     "bin": {
         "object-based-media-schema": "./bin/validate"
     },


### PR DESCRIPTION
# Details
Makes the default `npm publish` behaviour, used in the Jenkins _Publish to NPMjs (Public)_ step, allow public access.

# Ticket / issue URL
Ticket / issue URL: None; addresses current deploy failure.

# PR Checks
(tick as appropriate) 

- [x] ~PR is linked to ticket / issue~
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [x] PR has the package.json version bumped 
