### PR TITLE
feat: allow reordering end links

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "object-based-media-schema",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "JSON schemas which describe a common language for object-based media",
     "main": "lib/validate.js",
     "keywords": ["BBC", "BBC Research & Development", "schema", "interactive", "media", "object", "personalised"],
@@ -10,7 +10,7 @@
     },
     "publishConfig": {
         "access": "public"
-    },    
+    },
     "bin": {
         "object-based-media-schema": "./bin/validate"
     },

--- a/schemas/narrative_element_link/update.json
+++ b/schemas/narrative_element_link/update.json
@@ -47,10 +47,38 @@
                 "link_type": {
                     "type": "string",
                     "enum": [
-                        "CHOOSE_BEGINNING",
+                        "CHOOSE_BEGINNING"
+                    ],
+                    "description": "Return to parent story and choose a new beginning."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "[optional] free-text description of this link"
+                }
+            },
+            "required": [
+                "condition",
+                "link_type"
+            ],
+            "additionalProperties": false
+        },
+        {
+            "type": "object",
+            "properties": {
+                "link_position": {
+                    "type": "number",
+                    "description": "Position to insert link into array of links. If property not provided then link is inserted at the end of the array"
+                },
+                "condition": {
+                    "$ref": "/expression.json#",
+                    "description": "A boolean expression written in JsonLogic, which includes the JSONLogic data components"
+                },
+                "link_type": {
+                    "type": "string",
+                    "enum": [
                         "END_STORY"
                     ],
-                    "description": "CHOOSE_BEGINNING: return to parent story and choose a new beginning. END_STORY: This will either end the experience, or pass control back to the narrative element holding this story"
+                    "description": "This will either end the experience, or pass control back to the narrative element holding this story"
                 },
                 "description": {
                     "type": "string",


### PR DESCRIPTION
# Details
Modifies the update-schema for story links to allow specifying a link position for end links; and so allow reordering them like narrative links.

# Ticket / issue URL
Ticket / issue URL: https://jira.dev.bbc.co.uk/browse/PRODTOOLS-2671

# PR Checks
(tick as appropriate) 

- [x] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [x] PR has the package.json version bumped 
