### PR TITLE
feat: map overlay behaviour

### DIFF
--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -279,6 +279,7 @@ The `type` attribute is given as the URN below prefixed with: `urn:x-object-base
 | Text overlay | `textoverlay/v1.0` | Display some text over the content | See below for details ||
 | Link choices | `showlinkchoices/v1.0` | Display text or icons to allow the user to choose between valid links. | See below for details | Only those links from this representation whose conditions evaluate to `true` will be presented. |
 | Show variable panel | `showvariablepanel/v1.0` | Display an interface to allow users to set the values of one or more story variables | See below for details ||
+| Link Map Overlay | `mapoverlay/v1.0` | Places an invisible set of clickable rectangles on the screen (e.g., over an image or video) that can be used to navigate to Narrative Elements. | See below for details | This behaviour overrides the concepts of links, so link conditions are not evaluated. |
 
 The attributes omitted from the table above are as follows:
 
@@ -334,6 +335,11 @@ The attributes omitted from the table above are as follows:
     - `max_label` (String) - text to be rendered at the upper end of a scale for variables of type `number`
     - `precise_entry` (boolean) - Determines whether or not the user can enter an exact value for a variable of type `number` (e.g., HTML number input rather than a slider)
 
+#### `mapoverlay`
+* `links` (Array of Objects, required) - Defines a set of rectangles on the screen; each has the UUID of the element that it links to and the position and size of the rectangle:
+    - `narrative_element_id` string defining the Narrative Element that clicking on the rectangle will navigate to
+    - `position` (Object) with `left`, `top`, `width`, `height` as number attributes specifying location within the player using percent
+  
 ### Example
 [Representation example](../samples/sample.representation.json)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bbc/object-based-media-schema",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "description": "JSON schemas which describe a common language for object-based media",
     "main": "lib/validate.js",
     "keywords": [

--- a/schemas/representation/types.json
+++ b/schemas/representation/types.json
@@ -534,6 +534,59 @@
                    "additionalProperties": false
                 },
                 {
+                    "title": "Link Map Overlay Behaviour",
+                    "properties": {
+                        "id": {},
+                        "type":{
+                            "type":"string",
+                            "enum": [
+                                "urn:x-object-based-media:representation-behaviour:mapoverlay/v1.0"
+                            ]
+                        },
+                        "links": {
+                            "type": "array",
+                            "description": "List of links with rectangles defining click areas",
+                            "items": {
+                                "title": "Link area",
+                                "type": "object",
+                                "properties": {
+                                    "narrative_element_id": {
+                                        "type": "string",
+                                        "description": "UUID of Narrative Element the link points at"
+                                    },
+                                    "position": {
+                                        "type": "object",
+                                        "description": "Position and size of link area on screen, using percentages",
+                                        "properties": {
+                                            "top": {
+                                                "description": "Distance of top edge of link area from top of player (%)",
+                                                "type": "number"
+                                            },
+                                            "left": {
+                                                "description": "Distance of left edge of link area from left of player (%)",
+                                                "type": "number"
+                                            },
+                                            "width": {
+                                                "description": "Width of link area, in %",
+                                                "type": "number"
+                                            },
+                                            "height": {
+                                                "description": "Height of link area (%)",
+                                                "type": "number"
+                                            }
+                                        },
+                                        "additionalProperties": false,
+                                        "required": ["top", "left", "width", "height"]
+                                }
+                            }
+                        },
+                             "additionalProperties": false
+                        }
+                    },
+                   "required": ["type", "links"],
+                   "additionalProperties": false
+                },
+                {
                     "title": "Manipulate Variables Behaviour",
                     "properties": {
                         "id": {


### PR DESCRIPTION
# Details
Adds a new behaviour which can be used to render maps.  The behaviour defines a set of rectangles each with a target narrative element id.  When the behaviour is in use, clicking on the part of the screen defined by the given rectangle will navigate to the given Narrative Element

## Note for consideration
This overrides the concept of links, as no link is required between the NE on which the behaviour is being used and the target.  We could constrain this to only 'render' the rectangles with valid links, or take the extra flexibility as is, and recognise that it could lead to broken (unplayable) stories

# Ticket / issue URL
Ticket / issue URL: 

# PR Checks
(tick as appropriate) 

- [ ] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
