### PR TITLE
feat: new behaviour that shows an icon to toggle other behaviours

### DIFF
--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -280,6 +280,7 @@ The `type` attribute is given as the URN below prefixed with: `urn:x-object-base
 | Link choices | `showlinkchoices/v1.0` | Display text or icons to allow the user to choose between valid links. | See below for details | Only those links from this representation whose conditions evaluate to `true` will be presented. |
 | Show variable panel | `showvariablepanel/v1.0` | Display an interface to allow users to set the values of one or more story variables | See below for details ||
 | Link Map Overlay | `mapoverlay/v1.0` | Places an invisible set of clickable rectangles on the screen (e.g., over an image or video) that can be used to navigate to Narrative Elements. | See below for details | This behaviour overrides the concepts of links, so link conditions are not evaluated. |
+| Behaviour Toggle Icon | `iconbehaviour/v1.0` | This places an icon on screen; clicking the icon toggles a set of other behaviours (clicks alternately start all behaviours and clear all behaviours) | See below for details ||
 
 The attributes omitted from the table above are as follows:
 
@@ -339,6 +340,12 @@ The attributes omitted from the table above are as follows:
 * `links` (Array of Objects, required) - Defines a set of rectangles on the screen; each has the UUID of the element that it links to and the position and size of the rectangle:
     - `narrative_element_id` string defining the Narrative Element that clicking on the rectangle will navigate to
     - `position` (Object) with `left`, `top`, `width`, `height` as number attributes specifying location within the player using percent
+
+#### `iconbehaviour`
+* `icon` (Object, required) specifying the icon image and its position on screen
+  - `image` string, `behaviour_asset_collection_mapping_id` UUID of an asset collection in the `asset_collections` attribute)
+  - `position` (Object) with `left`, `top`, `width`, `height` as number attributes specifying location of the icon within the player using percent
+* `behaviours` (Array of Objects, required) - a set of behaviours that will be run and cleared when the icon is clicked.  For example, `showimage` and `mapoverlay` behaviours could be combined to create a clickable navigation map that appears/disappears when the user clicks the icon.
   
 ### Example
 [Representation example](../samples/sample.representation.json)

--- a/schemas/representation/types.json
+++ b/schemas/representation/types.json
@@ -715,6 +715,63 @@
                     "additionalProperties": false
                 },
                 {
+                    "title": "Behaviour Toggle Icon Behaviour",
+                    "description": "Behaviour that renders an icon, clicking this toggles other behaviours on/off",
+                    "properties": {
+                        "id": {},
+                        "type":{
+                            "type":"string",
+                            "enum": [
+                                "urn:x-object-based-media:representation-behaviour:iconbehaviour/v1.0"
+                            ]
+                        },
+                        "icon": {
+                            "type":"object",
+                            "properties": {
+                                "image": {
+                                    "type": "string",
+                                    "description": "Behaviour Id for mapping to Asset Collection."
+                                },
+                                "position": {
+                                    "type": "object",
+                                    "description": "Position and size of link area on screen, using percentages",
+                                    "properties": {
+                                        "top": {
+                                            "description": "Distance of top edge of link area from top of player (%)",
+                                            "type": "number"
+                                        },
+                                        "left": {
+                                            "description": "Distance of left edge of link area from left of player (%)",
+                                            "type": "number"
+                                        },
+                                        "width": {
+                                            "description": "Width of link area, in %",
+                                            "type": "number"
+                                        },
+                                        "height": {
+                                            "description": "Height of link area (%)",
+                                            "type": "number"
+                                        }
+                                    },
+                                    "additionalProperties": false,
+                                    "required": ["top", "left", "width", "height"]
+                                }
+                            },
+                            "description": "Image and position of icon",
+                            "required": ["image", "position"]
+                        },
+                        "behaviours": {
+                            "type": "array",
+                            "items": {
+                                "title": "Behaviour to toggle",
+                                "$ref": "#/definitions/behaviour_types"
+                            }
+                        }
+                    },
+                    "required": ["icon", "behaviours"],
+                    "additionalProperties": false
+                },
+                {
                     "title": "Show Variable Panel",
                     "properties": {
                         "id": {},


### PR DESCRIPTION
# Details
Another experimental behaviour.  This one takes data for an icon (image and position) and an array of behaviours.  Clicking the icon starts the behaviours, clicking again clears them (and so on).

### Note
Could get some strange behaviour with some types of behaviour (not sure how it would work with pauses!); best used with behaviours that show some UI or manipulate a variable.  Don't know if we want to constrain it in the schema though.

# Ticket / issue URL
Ticket / issue URL: 

# PR Checks
(tick as appropriate) 

- [ ] PR is linked to ticket / issue
- [ ] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
