### PR TITLE
fix: change direcory ownership *after* it has been created

### DIFF
--- a/.jenkins/Dockerfile
+++ b/.jenkins/Dockerfile
@@ -1,9 +1,10 @@
-FROM node:10
+FROM node:12.18
 
 RUN apt-get -y update && apt-get -y install netcat-openbsd
 
 ENV HOME /var/tmp/jenkins
 RUN useradd -u 997 -md $HOME jenkins
+RUN chmod -R a+rw /var/tmp/jenkins
 USER jenkins
 
 RUN mkdir $HOME/.ssh


### PR DESCRIPTION
# Details
Sets /var/tmp/jenkins to be globally read/write, allowing the user with id 999 to write to it.
Upgrade version of node used in container

# Ticket / issue URL
Ticket / issue URL: https://jira.dev.bbc.co.uk/browse/PRODTOOLS-3422

# PR Checks
(tick as appropriate) 

- [x] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
