### PR TITLE
feat: fade in and out behaviours

### DIFF
--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -282,6 +282,9 @@ The `type` attribute is given as the URN below prefixed with: `urn:x-object-base
 | Link Map Overlay | `mapoverlay/v1.0` | Places an invisible set of clickable rectangles on the screen (e.g., over an image or video) that can be used to navigate to Narrative Elements. | See below for details | This behaviour overrides the concepts of links, so link conditions are not evaluated. |
 | Fade in | `fadein/v1.0` | Apply a colour overlay, fading in over a given duration | `colour` (string, css colour) and `duration` (number, time in s) | Typically applied as a during behaviour with `start_time` 0 |
 | Fade out | `fadeout/v1.0` | Apply a colour overlay, then fade it out over a given duration | `colour` (string, css colour) and `duration` (number, time in s) | Typically applied as a during behaviour with `start_time` of the media duration minus the `duration` |
+| Fade audio in | `fadeaudioin/v1.0` | Set the foreground audio volume to an initial value, then fade up to last user set value over a given duration |  `duration` (number, time in s) and optional `initialVolume` (default is 0) | |
+| Fade audio out | `fadeaudioout/v1.0`| Fade the foreground audio down to the given value over a given duration |  `duration` (number, time in s) and optional `targetVolume` (default is 0) | |
+
 
 The attributes omitted from the table above are as follows:
 

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -280,6 +280,8 @@ The `type` attribute is given as the URN below prefixed with: `urn:x-object-base
 | Link choices | `showlinkchoices/v1.0` | Display text or icons to allow the user to choose between valid links. | See below for details | Only those links from this representation whose conditions evaluate to `true` will be presented. |
 | Show variable panel | `showvariablepanel/v1.0` | Display an interface to allow users to set the values of one or more story variables | See below for details ||
 | Link Map Overlay | `mapoverlay/v1.0` | Places an invisible set of clickable rectangles on the screen (e.g., over an image or video) that can be used to navigate to Narrative Elements. | See below for details | This behaviour overrides the concepts of links, so link conditions are not evaluated. |
+| Fade in | `fadein/v1.0` | Apply a colour overlay, fading in over a given duration | `colour` (string, css colour) and `duration` (number, time in s) | Typically applied as a during behaviour with `start_time` 0 |
+| Fade out | `fadeout/v1.0` | Apply a colour overlay, then fade it out over a given duration | `colour` (string, css colour) and `duration` (number, time in s) | Typically applied as a during behaviour with `start_time` of the media duration minus the `duration` |
 
 The attributes omitted from the table above are as follows:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bbc/object-based-media-schema",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "description": "JSON schemas which describe a common language for object-based media",
     "main": "lib/validate.js",
     "keywords": [

--- a/schemas/representation/types.json
+++ b/schemas/representation/types.json
@@ -366,6 +366,52 @@
                     "additionalProperties": false
                 },
                 {
+                    "title": "Fade in Behaviour",
+                    "properties": {
+                        "id": {},
+                        "type":{
+                            "type":"string",
+                            "enum": [
+                                "urn:x-object-based-media:representation-behaviour:fadein/v1.0"
+                            ]
+
+                        },
+                        "colour": {
+                            "description": "In form rgba(R, G, B, A)",
+                            "type":"string"
+                        },
+                        "duration": {
+                            "description": "time to fade from colour to fully opaque (seconds)",
+                            "type": "number"
+                        }
+                    },
+                     "required": ["colour", "duration"],
+                     "additionalProperties": false
+                },
+                {
+                    "title": "Fade out Behaviour",
+                    "properties": {
+                        "id": {},
+                        "type":{
+                            "type":"string",
+                            "enum": [
+                                "urn:x-object-based-media:representation-behaviour:fadeout/v1.0"
+                            ]
+
+                        },
+                        "colour": {
+                            "description": "In form rgba(R, G, B, A)",
+                            "type":"string"
+                        },
+                        "duration": {
+                            "description": "time to fade from invisible to colour (seconds)",
+                            "type": "number"
+                        }
+                    },
+                     "required": ["colour", "duration"],
+                     "additionalProperties": false
+                },
+                {
                     "title": "Opaque Colour Overlay Behaviour",
                     "properties": {
                         "id": {},

--- a/schemas/representation/types.json
+++ b/schemas/representation/types.json
@@ -412,6 +412,52 @@
                      "additionalProperties": false
                 },
                 {
+                    "title": "Fade audio in Behaviour",
+                    "properties": {
+                        "id": {},
+                        "type":{
+                            "type":"string",
+                            "enum": [
+                                "urn:x-object-based-media:representation-behaviour:fadeaudioin/v1.0"
+                            ]
+
+                        },
+                        "startVolume": {
+                            "description": "Value between 1 and 0 to set the volume at for start of fade (default 0)",
+                            "type":"number"
+                        },
+                        "duration": {
+                            "description": "time to fade from startVolume to previously user set volume",
+                            "type": "number"
+                        }
+                    },
+                     "required": ["duration"],
+                     "additionalProperties": false
+                },
+                {
+                    "title": "Fade audio out Behaviour",
+                    "properties": {
+                        "id": {},
+                        "type":{
+                            "type":"string",
+                            "enum": [
+                                "urn:x-object-based-media:representation-behaviour:fadeaudioout/v1.0"
+                            ]
+
+                        },
+                        "targetVolume": {
+                            "description": "Value between 0 and 1 to fade the volume to (default 0)",
+                            "type":"number"
+                        },
+                        "duration": {
+                            "description": "time to fade from current volume to targetVolume",
+                            "type": "number"
+                        }
+                    },
+                     "required": ["duration"],
+                     "additionalProperties": false
+                },
+                {
                     "title": "Opaque Colour Overlay Behaviour",
                     "properties": {
                         "id": {},


### PR DESCRIPTION
# Details
Four new behaviours.

* Two that allow us to (visually) fade in or out of an element.  I would anticipate typical application would be to apply with colour `#000`, duration around 2s and a `fadein` as during behaviour at `start_time` = 0 and a `fadeout` shortly before the end of the media.
* Two that allow us to fade audio.  `fadeaudioin` sets the audio to an intialValue (typically 0, I guess) and fades up to whatever the volume was last set to; `fadeaudioout` fades the volume down to target value (unless already at or below that level).  The target and initial values allow ducking - e.g., at 10s drop volume to 0.2, then rise back to previous value at 15s.  Otherwise can be combined with visual fades to fade volume and visuals to/from black and silent.

# Ticket / issue URL
Ticket / issue URL: 

# PR Checks
(tick as appropriate) 

- [ ] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [x] PR has the package.json version bumped 
