### PR TITLE
build: take UID for jenkins user from a build-arg

### DIFF
--- a/.jenkins/Dockerfile
+++ b/.jenkins/Dockerfile
@@ -2,10 +2,13 @@ FROM node:12.18
 
 RUN apt-get -y update && apt-get -y install netcat-openbsd
 
+ARG USERID
+RUN echo "UID is $USERID"
+
 ENV HOME /var/tmp/jenkins
-RUN useradd -u 997 -md $HOME jenkins
-RUN chmod -R a+rw /var/tmp/jenkins
+RUN useradd -u "$USERID" -md "$HOME" jenkins
+RUN chmod -R a+rw "$HOME"
 USER jenkins
 
-RUN mkdir $HOME/.ssh
-ADD known_hosts $HOME/.ssh/known_hosts
+RUN mkdir "${HOME}/.ssh"
+ADD known_hosts "${HOME}/.ssh/known_hosts"


### PR DESCRIPTION
# Details
Makes use of the USERID build-arg that is now passed from the Jenkins pipeline, to ensure that the jenkins user inside docker matches the outside user

# Ticket / issue URL
Ticket / issue URL: https://jira.dev.bbc.co.uk/browse/PRODTOOLS-3422

# PR Checks
(tick as appropriate) 

- [x] PR is linked to ticket / issue
- [ ] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
