### PR TITLE
Fix: Loosen UUID restraint to accommodate UUIDv5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bbc/object-based-media-schema",
-    "version": "1.0.9",
+    "version": "1.0.10",
     "description": "JSON schemas which describe a common language for object-based media",
     "main": "lib/validate.js",
     "keywords": [

--- a/schemas/core.json
+++ b/schemas/core.json
@@ -7,7 +7,7 @@
         },
         "uuid": {
             "type": "string",
-            "pattern": "^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-4[A-Fa-f0-9]{3}-[89aAbB][A-Fa-f0-9]{3}-[A-Fa-f0-9]{12}$"
+            "pattern": "^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[89aAbB][A-Fa-f0-9]{3}-[A-Fa-f0-9]{12}$"
         },
         "date": {
             "type": "string",


### PR DESCRIPTION
# Details
UUID v5 does not enforce that the third set of characters begins with a "4". This PR removes that  restriction.

# Ticket / issue URL
Ticket / issue URL: 

# PR Checks
(tick as appropriate) 

- [ ] PR is linked to ticket / issue
- [ ] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
