### PR TITLE
refactor: renames background_ids background_audio_ids

### DIFF
--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -205,7 +205,7 @@ A representation type is used by the player to determine what media playback mod
 The `asset_collections` field contains an Object whose attributes will depend on the type of representation denoted in the `representation_type` field.
 
 * ```foreground_id```       (String: UUID, required) - id of an ```asset_collection``` that is the primary content (depending on the type, e.g., an ```IMAGE``` asset_collection for an ```image``` representation)
-* ```background_ids```      (Array of UUID Strings) - ids of ```asset_collection```s of background media, e.g., ```SIMPLE_AUDIO``` assets that accompany the primary presentation.
+* ```background_audio_ids```      (Array of UUID Strings) - ids of ```asset_collection```s of background audio assets (e.g., ```SIMPLE_AUDIO```) that accompany the primary presentation.
 * ```background_image```      (String: UUID) - optional pointer to an ```asset_collection``` for `simple_audio` representations; if present this image will be displayed by the player application while the audio is playing
 * ```icon```                (Object) - pointers to ```asset_collection```s, used in chapter navigation menus that might be surfaced by the player application.  This Object contains two attributes:
     - `default_id`  (String: UUID, required) - an icon to be displayed to represent this representation in chapter navigation.

--- a/samples/sample.representation.json
+++ b/samples/sample.representation.json
@@ -8,7 +8,7 @@
     "representation_type": "urn:x-object-based-media:representation-types:simple-av/v1.0",
     "asset_collections": {
         "foreground_id": "2cf4f4a5-5e6a-4eb3-b5d4-6c957f8b8b0c",
-        "background_ids": ["2cf4f4a5-5e6a-4eb3-b5d4-6c957f8b8b0c"],
+        "background_audio_ids": ["2cf4f4a5-5e6a-4eb3-b5d4-6c957f8b8b0c"],
         "icon": {
             "default_id":"1dbcb2c6-adf4-4e68-b7fe-fe3ce458bb79"
         },

--- a/schemas/representation/types.json
+++ b/schemas/representation/types.json
@@ -64,7 +64,7 @@
                             "foreground_id": {
                                 "$ref": "/uuids.json#/definitions/asset_collection_uuid"
                             },
-                            "background_ids": {
+                            "background_audio_ids": {
                                 "$ref": "#/definitions/asset_collections_background"
                             },
                             "icon": {
@@ -96,7 +96,7 @@
                             "foreground_id": {
                                 "$ref": "/uuids.json#/definitions/asset_collection_uuid"
                             },
-                            "background_ids": {
+                            "background_audio_ids": {
                                 "$ref": "#/definitions/asset_collections_background"
                             },
                             "icon": {
@@ -128,7 +128,7 @@
                             "foreground_id": {
                                 "$ref": "/uuids.json#/definitions/asset_collection_uuid"
                             },
-                            "background_ids": {
+                            "background_audio_ids": {
                                 "$ref": "#/definitions/asset_collections_background"
                             },
                             "background_image": {
@@ -199,7 +199,7 @@
                                 "$ref": "/uuids.json#/definitions/asset_collection_uuid",
                                 "description": "UUID pointing to image"
                             },
-                            "background_ids": {
+                            "background_audio_ids": {
                                 "$ref": "#/definitions/asset_collections_background"
                             },
                             "icon": {
@@ -268,7 +268,7 @@
                                 "$ref": "/uuids.json#/definitions/asset_collection_uuid",
                                 "description": "UUID pointing to 360 image"
                             },
-                            "background_ids": {
+                            "background_audio_ids": {
                                 "$ref": "#/definitions/asset_collections_background"
                             },
                             "icon": {


### PR DESCRIPTION
# Details
Renames `background_ids` in `representation > asset_collections` to be more explicit: `background_audio_ids`

# Ticket / issue URL
Ticket / issue URL: https://jira.dev.bbc.co.uk/browse/PRODTOOLS-2703

# PR Checks
(tick as appropriate) 

- [x] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
