### PR TITLE
fix: removes looping-audio asset collection type

### DIFF
--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -373,7 +373,6 @@ The table below presents the possible values for `asset_collection_type` with a 
 | `simple-av/v1.0` | Audio video content | `av_src` (URI) |
 | `immersive/v1.0` | 360 audio video |`av_src` (URI) |
 | `simple-audio/v1.0` | audio content | `audio_src` (URI)|
-| `looping-audio/v1.0` | audio content that loops | `audio_src` (URI)|
 | `simple-text/v1.0` | Plain text | `text_src` (URI) |
 | `markdown/v1.0` | Markdown text | `markdown_src` (URI) |
 | `image/v1.0` | An image | `image_src` (URI) |

--- a/schemas/asset_collection/types.json
+++ b/schemas/asset_collection/types.json
@@ -91,36 +91,6 @@
                     }
                 },
                 {
-                    "title": "LOOPING AUDIO",
-                    "description": "(Deprecated) LOOPING AUDIO is deprecated in favour of SIMPLE AUDIO with looping flag",
-                    "properties": {
-                        "asset_collection_type": {
-                            "type": "string",
-                            "enum": [
-                                "urn:x-object-based-media:asset-collection-types:looping-audio/v1.0"
-                            ]
-                        },
-                        "assets": {
-                            "type": "object",
-                            "properties": {
-                                "audio_src": {
-                                    "type": "string",
-                                    "format":"uri",
-                                    "description": "URI pointing to audio"
-                                },
-                                "sub_src":{
-                                    "type": "string",
-                                    "format":"uri",
-                                    "description": "URI of subtitles."
-                                }
-                            },
-                            "required": ["audio_src"],
-                            "additionalProperties": false
-                        }
-                    },
-                    "not": { "required": [ "loop" ] }
-                },
-                {
                     "title": "SIMPLE AUDIO",
                     "properties": {
                         "asset_collection_type": {


### PR DESCRIPTION
# Details
Removes the `looping-audio` asset collection type.  This is no longer used.

# Ticket / issue URL
Ticket / issue URL: https://jira.dev.bbc.co.uk/browse/PRODTOOLS-2181

# PR Checks
(tick as appropriate) 

- [x] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
