### PR TITLE
feat: adds pause_content attribute to variable panel

### DIFF
--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -333,6 +333,7 @@ The attributes omitted from the table above are as follows:
 #### `showvariablepanel`
 * `panel_label`  (String, free text, required) - A label to render as a title for the interface
 * `background_colour` (String, HTML colour format) - A colour to use as the background colour of the interface
+* `pause_content` (boolean) - Determines whether or not the timer on the content pauses (e.g., video pause) while the panel is visible.  Default is true.  Regardless of this setting, the representation will not complete until the panel is finished.
 * `variables` (Array of Objects, required) - Defines which variables to include in the panel, and a question for each:
     - `variable_name` (String, required) - the name of the variable as defined in the `story` `variables` attribute
     - `label` (String, required) -  some text to be rendered next to the variable setting control (e.g., a question)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bbc/object-based-media-schema",
-    "version": "1.0.10",
+    "version": "1.0.11",
     "description": "JSON schemas which describe a common language for object-based media",
     "main": "lib/validate.js",
     "keywords": [

--- a/schemas/representation/types.json
+++ b/schemas/representation/types.json
@@ -820,6 +820,10 @@
                             "type": "string",
                             "description": "Label to display when panel is displayed (question or prompt)"
                         },
+                        "pause_content": {
+                            "type": "boolean",
+                            "description": "Should the video/audio/image timer pause while the panel is showing"
+                        },
                         "background_colour": {
                             "type": "string",
                             "description": "Background colour for the panel as html string"


### PR DESCRIPTION
# Details
This is in preparation for removing `started` behaviours.  If used as a `during` behaviour, currently the content will carry on playing under a variables panel.  This adds an attribute to the behaviour so that it can be used as a during behaviour and have the content pause.

The assumption is that if this is true the video will pause (or the image timer will pause).  If it is false, the content will continue playing (or the timer will continue), but the representation will not complete until the panel has finished (i.e., it will pause at the end).

# Ticket / issue URL
Ticket / issue URL: https://jira.dev.bbc.co.uk/browse/PRODTOOLS-3460

# PR Checks
(tick as appropriate) 

- [x] PR is linked to ticket / issue
- [x] PR title (merged commit message) follows https://www.conventionalcommits.org/en/v1.0.0/ conventions
- [ ] PR has the package.json version bumped 
